### PR TITLE
nodes randomly assume leadership duties

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Complete Rust crate documention is available, and examples of use are available 
 
 ## Distributed Algorithm
 
-This KCL uses distributed consensus, whereby the consumers are collaborative, there is no leader, and no node is (intentionally) malicious. The network is resilient against any subset of consumers failing. This is in contrast with the Java KCL which has an elected leader for some aspects of shard syncing.
+This KCL uses distributed consensus, whereby the consumers are collaborative and no node is (intentionally) malicious. The network is resilient against any subset of consumers failing. Calls to `ListShards` are only made by a random subset of nodes to limit API calls, in contrast with the Java KCL which has an elected leader that is a central point of failure.
 
 The goal is for a fleet (of unknown size) of consumers to consume from distinct kinesis shards, having an even distribution of work, and with minimal disruption to the service. Every record in the stream is processed using an "at least once delivery" guarantee from the point of it entering the kinesis stream until it has been successfully checkpointed by the user.
 
@@ -270,14 +270,8 @@ That has now become available and we aim to add EFO support shortly.
 
 The following endpoints are necessary to be able to implement EFO
 
-- [`RegitserStreamConsumer`]( https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html)
+- [`RegisterStreamConsumer`]( https://docs.aws.amazon.com/kinesis/latest/APIReference/API_RegisterStreamConsumer.html)
 - [`SubscribeToShard`](https://docs.aws.amazon.com/kinesis/latest/APIReference/API_SubscribeToShard.html)
-
-## Potential ListShards Usage Limits
-
-The `ListShards` endpoint has a limit of 1000 requests per second, per stream, and the call is paged (maximum of 1,000 shards per response). Given that every consumer would poll this every 20 seconds, it is possible that for extremely large streams, with large numbers of recent resharding events, may exceed the account limits. This is largely irrelevant when EFO is not available as it places a natural limit on the number of consumers.
-
-This could be mitigated by having the lease manager randomise, back off or, following the lead of the AWS Java implementation, using elected leaders to perform shard syncing. We believe that randomness is more reliable in the typical case, since anything involving a leader election can have chronic failure modes.
 
 ## Hot Shard Mitigation
 

--- a/tests/calculate_acquire.json
+++ b/tests/calculate_acquire.json
@@ -4,7 +4,6 @@
         "leases_to_acquire": 1,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [],
         "leases": [],
         "heartbeats": {},
         "available": [],
@@ -16,9 +15,6 @@
         "leases_to_acquire": 1,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } }
         ],
@@ -33,9 +29,6 @@
         "leases_to_acquire": 1,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner": "worker-001", "checkpoint": { "sequence_number": "TRIM_HORIZON" } }
         ],
@@ -51,16 +44,6 @@
         "leases_to_acquire": 1,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
@@ -86,16 +69,6 @@
         "leases_to_acquire": 8,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
@@ -121,16 +94,6 @@
         "leases_to_acquire": 8,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
@@ -156,16 +119,6 @@
         "leases_to_acquire": 8,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003", "parent_shard_id": "shard-001", "adjacent_parent_shard_id": "shard-002" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner":         null, "checkpoint": { "sequence_number": "SHARD_END" } },
@@ -191,16 +144,6 @@
         "leases_to_acquire": 8,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner":         null, "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner": "worker-001", "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
@@ -229,16 +172,6 @@
         "leases_to_acquire": 8,
         "max_leases": 8,
         "worker": "worker-000",
-        "shards": [
-            { "shard_id": "shard-000" },
-            { "shard_id": "shard-001" },
-            { "shard_id": "shard-002" },
-            { "shard_id": "shard-003" },
-            { "shard_id": "shard-004" },
-            { "shard_id": "shard-005" },
-            { "shard_id": "shard-006" },
-            { "shard_id": "shard-007" }
-        ],
         "leases": [
             { "lease_key": "shard-000", "lease_owner": "worker-000", "checkpoint": { "sequence_number": "TRIM_HORIZON" } },
             { "lease_key": "shard-001", "lease_owner": "worker-001", "checkpoint": { "sequence_number": "TRIM_HORIZON" } },

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -36,7 +36,7 @@ pub async fn init() -> (
     // tracing_subscriber::fmt().json().init();
     tracing_subscriber::fmt().init();
 
-    let config = aws_config::load_defaults(aws_config::BehaviorVersion::v2024_03_28()).await;
+    let config = aws_config::load_defaults(aws_config::BehaviorVersion::v2025_01_17()).await;
 
     let cw = aws_sdk_cloudwatch::Client::new(&config);
     let ddb = aws_sdk_dynamodb::Client::new(&config);


### PR DESCRIPTION
This unblocks EFO work because without this change (as documented in the previous version of the README) we could easily start to hit API usage limits on the kinesis `ListShards` endpoint.